### PR TITLE
Bump protobuf from 3.12.0 to 4.30.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.12.0</version>
+            <version>4.30.2</version>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>
@@ -65,7 +65,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:4.30.2:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.36.0:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>src/main/resources</protoSourceRoot>


### PR DESCRIPTION
Since version 3.12.0 has 6 known vulnerabilities, protobuf is upgraded to the latest stable version 4.30.2. 